### PR TITLE
feat: add ignore file configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A github action that compare a list of JSON files an return the missing keys between each other.
 
+## Action configurations
+
+| Input Name   | Description                                                                                                     | Required | Default            |
+|--------------|-----------------------------------------------------------------------------------------------------------------|----------|--------------------|
+| `files`      | List of JSON file paths to check between each other. Should be at least 2 files.                                 | `false`  | -                  |
+| `search_path`| Path to a folder that will be inspected to search all JSON files and compare each other.                         | `false`  | -                  |
+| `search_pattern` | Regular expression used on search path to find desired files.                                                  | `false`  | `\.json$`          |
+| `ignore_file`| Path to a specific ignore file configuration                                                                    | `false`  | `.json-diff-ignore.json` |
+
 ## Usage
 
 You can compare specific files using the next configuration:
@@ -28,3 +37,31 @@ Or if you want to search on a specific route you can use the next configuration:
 ```
 
 This will find on the specified route all files that match the `search_pattern` to compare each other
+
+### Ignore rules
+
+If you need to ignore some specific keys on certain files you can use an ignore json file on your project
+root. By the fault the name of this files is `.json-diff-ignore.json` and has this structure:
+
+```json
+[
+  {
+    "pattern": "regexp/file\\.json$",
+    "ignoreKeys": ["key1"]
+  },
+  {
+    "pattern": "regexp/file2\\.json$",
+    "ignoreKeys": ["key2"]
+  }
+]
+```
+
+If you what to specify a specific path to find the ignore file you can do that by adding the next configuration:
+
+```yml
+- name: Run JSON Diff Action
+  uses: Drafteame/json-diff-action@main
+  with:
+    # ...
+    ignore_file: /path/to/.json-diff-ignore.json
+```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,13 @@ inputs:
     description: Regular expression used on search path to find desired files.
     required: false
     default: '\\.json$'
+  ignore_file:
+    description: Path to a specific ignore file configuration
+    required: false
+    default: '.json-diff-ignore.json'
 
 runs:
   using: "docker"
   image: "Dockerfile"
+
+

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const main = () => {
     core.getInput("files"),
     core.getInput("search_path"),
     core.getInput("search_pattern"),
+    core.getInput("ignore_file"),
   );
 
   try {

--- a/tests/Action.test.js
+++ b/tests/Action.test.js
@@ -37,6 +37,8 @@ describe("Action core functions", () => {
     const searchPath = ``;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
+
     try {
       new Action(files, searchPath, searchPattern);
     } catch (e) {
@@ -54,6 +56,7 @@ describe("Action core functions", () => {
     const searchPath = ``;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.returns(true);
 
     try {
@@ -76,6 +79,7 @@ describe("Action core functions", () => {
     const searchPath = ``;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.returns(true);
 
     try {
@@ -98,6 +102,7 @@ describe("Action core functions", () => {
     const searchPath = ``;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs("some/path/to/file1.json").returns(true);
     fsStub.existsSync.withArgs("some/path/to/file2.json").returns(false);
 
@@ -119,6 +124,7 @@ describe("Action core functions", () => {
     const searchPath = ``;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.returns(true);
 
     try {
@@ -137,6 +143,7 @@ describe("Action core functions", () => {
     const searchPath = `some/search/folder`;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(false);
 
     try {
@@ -156,6 +163,7 @@ describe("Action core functions", () => {
     const searchPath = `some/search/folder`;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(false);
 
@@ -176,6 +184,7 @@ describe("Action core functions", () => {
     const searchPath = `some/search/folder`;
     const searchPattern = ``;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -203,6 +212,7 @@ describe("Action core functions", () => {
     const searchPath = `some/search/folder`;
     const searchPattern = `json$`;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -228,6 +238,7 @@ describe("Action core functions", () => {
     const searchPath = `/some/search/folder/`;
     const searchPattern = `json$`;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -255,6 +266,7 @@ describe("Action core functions", () => {
     const searchPath = `/some/search/folder/`;
     const searchPattern = `json$`;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -311,6 +323,7 @@ describe("Action core functions", () => {
     const searchPath = `/some/search/folder/`;
     const searchPattern = `json$`;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -366,6 +379,7 @@ describe("Action core functions", () => {
     const searchPath = `/some/search/folder/`;
     const searchPattern = `json$`;
 
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(false);
     fsStub.existsSync.withArgs(searchPath).returns(true);
     isDirectoryStub.returns(true);
 
@@ -414,6 +428,164 @@ describe("Action core functions", () => {
       expect(JSON.stringify(missing)).to.be.equal(JSON.stringify(expected));
     } catch (e) {
       expect.fail(`Error: ${e.message}`);
+    }
+  });
+
+  it("Should load default ignore configuration", () => {
+    const files = `
+      some/path/to/file1.json
+      some/path/to/file2.json
+    `;
+    const searchPath = ``;
+    const searchPattern = ``;
+
+    let ignoreConfig = [
+      {
+        pattern: "file1\\.json",
+        ignoreKeys: ["key1", "key2"],
+      },
+      {
+        pattern: "file2\\.json",
+        ignoreKeys: ["key11", "key22"],
+      },
+    ];
+
+    fsStub.existsSync.withArgs(".json-diff-ignore.json").returns(true);
+
+    fsStub.readFileSync
+      .withArgs(".json-diff-ignore.json", {
+        encoding: "utf-8",
+      })
+      .returns(JSON.stringify(ignoreConfig));
+
+    fsStub.existsSync.returns(true);
+
+    try {
+      const action = new Action(files, searchPath, searchPattern);
+
+      expect(action.getFileList()).to.contains("some/path/to/file1.json");
+      expect(action.getFileList()).to.contains("some/path/to/file2.json");
+
+      expect(JSON.stringify(action.getIgnoreRules())).to.be.equal(
+        JSON.stringify(ignoreConfig),
+      );
+    } catch (e) {
+      expect.fail(`Error: ${e.message}`);
+      return;
+    }
+  });
+
+  it("Should load custom path for ignore file", () => {
+    const files = `
+      some/path/to/file1.json
+      some/path/to/file2.json
+    `;
+    const searchPath = ``;
+    const searchPattern = ``;
+    const ignoreFile = `path/to/.json-diff-ignore.json`;
+
+    let ignoreConfig = [
+      {
+        pattern: "file1\\.json",
+        ignoreKeys: ["key1", "key2"],
+      },
+      {
+        pattern: "file2\\.json",
+        ignoreKeys: ["key11", "key22"],
+      },
+    ];
+
+    fsStub.existsSync.withArgs(ignoreFile).returns(true);
+
+    fsStub.readFileSync
+      .withArgs(ignoreFile, {
+        encoding: "utf-8",
+      })
+      .returns(JSON.stringify(ignoreConfig));
+
+    fsStub.existsSync.returns(true);
+
+    try {
+      const action = new Action(files, searchPath, searchPattern, ignoreFile);
+
+      expect(action.getFileList()).to.contains("some/path/to/file1.json");
+      expect(action.getFileList()).to.contains("some/path/to/file2.json");
+
+      expect(JSON.stringify(action.getIgnoreRules())).to.be.equal(
+        JSON.stringify(ignoreConfig),
+      );
+    } catch (e) {
+      expect.fail(`Error: ${e.message}`);
+      return;
+    }
+  });
+
+  it("Should ignore keys if found on ignore configuration", () => {
+    const files = `
+      some/path/to/file1.json
+      some/path/to/file2.json
+    `;
+    const searchPath = ``;
+    const searchPattern = ``;
+    const ignoreFile = `path/to/.json-diff-ignore.json`;
+
+    let ignoreConfig = [
+      {
+        pattern: "file1\\.json",
+        ignoreKeys: ["key1"],
+      },
+      {
+        pattern: "file2\\.json",
+        ignoreKeys: ["key2"],
+      },
+    ];
+
+    fsStub.existsSync.withArgs(ignoreFile).returns(true);
+
+    fsStub.readFileSync
+      .withArgs(ignoreFile, {
+        encoding: "utf-8",
+      })
+      .returns(JSON.stringify(ignoreConfig));
+
+    fsStub.existsSync.returns(true);
+
+    let readOpts = { encoding: "utf-8" };
+
+    fsStub.readFileSync.withArgs("some/path/to/file1.json", readOpts).returns(
+      JSON.stringify({
+        common: 1,
+        missing1: "some",
+        missing2: "some",
+        key2: "asd",
+      }),
+    );
+
+    fsStub.readFileSync.withArgs("some/path/to/file2.json", readOpts).returns(
+      JSON.stringify({
+        common: 1,
+        missing1: "some",
+        missing2: "some",
+        key1: "asd",
+      }),
+    );
+
+    try {
+      const action = new Action(files, searchPath, searchPattern, ignoreFile);
+
+      expect(action.getFileList()).to.contains("some/path/to/file1.json");
+      expect(action.getFileList()).to.contains("some/path/to/file2.json");
+
+      expect(JSON.stringify(action.getIgnoreRules())).to.be.equal(
+        JSON.stringify(ignoreConfig),
+      );
+
+      const missing = action.run();
+
+      expect(JSON.stringify(missing)).to.be.equal(JSON.stringify({}));
+    } catch (e) {
+      expect.fail(`Error: ${e.message}`);
+      return;
     }
   });
 });


### PR DESCRIPTION
## Description

Add new options to configure an ignore file to create rules that allows to skip the check on certain keys if the file matches with the specified ignore pattern.

## Task Context

### What is the current behavior?

- No way to skip check on specific keys

### What is the new behavior?

- New action argument `ignore_file` that represents a path to an ignore json file for the action (default is `.json-diff-ignore.json` on project root)

### Additional Context

Struct of the ignore file:

```json
[
  {
    "pattern": "regexp/file\\.json$",
    "ignoreKeys": ["key1"]
  },
  {
    "pattern": "regexp/file2\\.json$",
    "ignoreKeys": ["key2"]
  }
]
```
